### PR TITLE
Some fixes

### DIFF
--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -21,7 +21,7 @@ struct XiaomiParseResult {
     TYPE_JQJCY01YM,
     TYPE_MUE4094RT,
     TYPE_WX08ZM,
-    TYPE_MJYD2S
+    TYPE_MJYD02YLA
   } type;
   std::string name;
   optional<float> temperature;
@@ -34,7 +34,7 @@ struct XiaomiParseResult {
   optional<float> tablet;
   optional<float> idle_time;
   optional<bool> is_active;
-  optional<bool> has_motion;
+  optional<bool> motion;
   bool has_data;        // 0x40
   bool has_capability;  // 0x20
   bool has_encryption;  // 0x08

--- a/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
+++ b/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
@@ -2,8 +2,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, binary_sensor, esp32_ble_tracker
 from esphome.const import CONF_MAC_ADDRESS, CONF_ID, CONF_BINDKEY, \
-    UNIT_PERCENT, ICON_BATTERY, CONF_BATTERY_LEVEL, CONF_ILLUMINANCE, UNIT_LUX, \
-    ICON_BRIGHTNESS_5, UNIT_MINUTE, ICON_TIMELAPSE, CONF_IDLE_TIME
+    CONF_DEVICE_CLASS, CONF_LIGHT, ICON_BRIGHTNESS_5, \
+    CONF_BATTERY_LEVEL, UNIT_PERCENT, ICON_BATTERY, \
+    CONF_IDLE_TIME, UNIT_MINUTE, ICON_TIMELAPSE
 
 DEPENDENCIES = ['esp32_ble_tracker']
 AUTO_LOAD = ['xiaomi_ble']
@@ -16,9 +17,12 @@ CONFIG_SCHEMA = cv.All(binary_sensor.BINARY_SENSOR_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(XiaomiMJYD02YLA),
     cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
     cv.Required(CONF_BINDKEY): cv.bind_key,
+    cv.Optional(CONF_DEVICE_CLASS, default='motion'): binary_sensor.device_class,
     cv.Optional(CONF_IDLE_TIME): sensor.sensor_schema(UNIT_MINUTE, ICON_TIMELAPSE, 0),
-    cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(UNIT_LUX, ICON_BRIGHTNESS_5, 0),
     cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 0),
+    cv.Optional(CONF_LIGHT): binary_sensor.BINARY_SENSOR_SCHEMA.extend({
+        cv.Optional(CONF_DEVICE_CLASS, default='light'): binary_sensor.device_class,
+    }),
 }).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA))
 
 
@@ -34,11 +38,11 @@ def to_code(config):
     if CONF_IDLE_TIME in config:
         sens = yield sensor.new_sensor(config[CONF_IDLE_TIME])
         cg.add(var.set_idle_time(sens))
-    if CONF_ILLUMINANCE in config:
-        sens = yield sensor.new_sensor(config[CONF_ILLUMINANCE])
-        cg.add(var.set_illuminance(sens))
     if CONF_BATTERY_LEVEL in config:
         sens = yield sensor.new_sensor(config[CONF_BATTERY_LEVEL])
         cg.add(var.set_battery_level(sens))
+    if CONF_LIGHT in config:
+        sens = yield binary_sensor.new_binary_sensor(config[CONF_LIGHT])
+        cg.add(var.set_light(sens))
 
     cg.add_library("mbedtls", "cdf462088d")

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
@@ -11,8 +11,8 @@ static const char *TAG = "xiaomi_mjyd02yla";
 void XiaomiMJYD02YLA::dump_config() {
   ESP_LOGCONFIG(TAG, "Xiaomi MJYD02YL-A");
   LOG_BINARY_SENSOR("  ", "Motion", this);
+  LOG_BINARY_SENSOR("  ", "Light", this->light_);
   LOG_SENSOR("  ", "Idle Time", this->idle_time_);
-  LOG_SENSOR("  ", "Illuminance", this->illuminance_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
@@ -43,14 +43,14 @@ bool XiaomiMJYD02YLA::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
     if (!(xiaomi_ble::report_xiaomi_results(res, device.address_str()))) {
       continue;
     }
-    if (res->has_motion.has_value())
-      this->publish_state(*res->has_motion);
     if (res->idle_time.has_value() && this->idle_time_ != nullptr)
       this->idle_time_->publish_state(*res->idle_time);
-    if (res->illuminance.has_value() && this->illuminance_ != nullptr)
-      this->illuminance_->publish_state(*res->illuminance);
     if (res->battery_level.has_value() && this->battery_level_ != nullptr)
       this->battery_level_->publish_state(*res->battery_level);
+    if (res->illuminance.has_value() && this->light_ != nullptr)
+      this->light_->publish_state((res->illuminance > 1) ? true : false);
+    if (res->motion.has_value())
+      this->publish_state(*res->motion); // motion event should be transmitted last
     success = true;
   }
 

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
@@ -23,15 +23,15 @@ class XiaomiMJYD02YLA : public Component,
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_idle_time(sensor::Sensor *idle_time) { idle_time_ = idle_time; }
-  void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
+  void set_light(binary_sensor::BinarySensor *light) { light_ = light; }
 
  protected:
   uint64_t address_;
   uint8_t bindkey_[16];
   sensor::Sensor *idle_time_{nullptr};
-  sensor::Sensor *illuminance_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
+  binary_sensor::BinarySensor *light_{nullptr};
 };
 
 }  // namespace xiaomi_mjyd02yla

--- a/esphome/components/xiaomi_mue4094rt/binary_sensor.py
+++ b/esphome/components/xiaomi_mue4094rt/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor, esp32_ble_tracker
-from esphome.const import CONF_MAC_ADDRESS, CONF_TIMEOUT, CONF_ID
+from esphome.const import CONF_MAC_ADDRESS, CONF_DEVICE_CLASS, CONF_TIMEOUT, CONF_ID
 
 DEPENDENCIES = ['esp32_ble_tracker']
 AUTO_LOAD = ['xiaomi_ble']
@@ -13,6 +13,7 @@ XiaomiMUE4094RT = xiaomi_mue4094rt_ns.class_('XiaomiMUE4094RT', binary_sensor.Bi
 CONFIG_SCHEMA = cv.All(binary_sensor.BINARY_SENSOR_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(XiaomiMUE4094RT),
     cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+    cv.Optional(CONF_DEVICE_CLASS, default='motion'): binary_sensor.device_class,
     cv.Optional(CONF_TIMEOUT, default='5s'): cv.positive_time_period_milliseconds,
 }).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA))
 

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
@@ -39,8 +39,8 @@ bool XiaomiMUE4094RT::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
     if (!(xiaomi_ble::report_xiaomi_results(res, device.address_str()))) {
       continue;
     }
-    if (res->has_motion.has_value()) {
-      this->publish_state(*res->has_motion);
+    if (res->motion.has_value()) {
+      this->publish_state(*res->motion);
       this->set_timeout("motion_timeout", timeout_, [this]() { this->publish_state(false); });
     }
     success = true;


### PR DESCRIPTION
## Description:
- variable naming fix (has_motion to motion);
- appropriate device_class now set by default (no more explicit configuration needed);
- payload's raw_offset calculation fix (length checking);
- illuminance sensor changed to binary_sensor as it doesn't contain an actual value (used as a flag in this nightlight);
- few miscodings fixed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
